### PR TITLE
More OS listings for Dolphin as a Wii emulator

### DIFF
--- a/Emulation/Emulators.md
+++ b/Emulation/Emulators.md
@@ -203,7 +203,7 @@ Linux|[DeSmuME](https://desmume.org/)|
 ||[SuperGCube](https://sourceforge.net/projects/supergcube/)|
 |Mac|[Dolphin](https://dolphin-emu.org/)|
 |Linux|[Dolphin](https://dolphin-emu.org/)|
-|Android|[Dolphin](https://dolphin-emulator.en.uptodown.com/android)|
+|Android|[Dolphin](https://dolphin-emu.org/)|
 
 &nbsp;
 **Nintendo Virtual Boy**
@@ -224,7 +224,7 @@ Linux|[DeSmuME](https://desmume.org/)|
 |Windows|[Dolphin](https://dolphin-emu.org/)|
 |Mac|[Dolphin](https://dolphin-emu.org/)|
 |Linux|[Dolphin](https://dolphin-emu.org/)|
-|Android|[Dolphin](https://dolphin-emulator.en.uptodown.com/android)|
+|Android|[Dolphin](https://dolphin-emu.org/)|
 
 &nbsp;
 **Nintendo Wii U**

--- a/Emulation/Emulators.md
+++ b/Emulation/Emulators.md
@@ -222,6 +222,9 @@ Linux|[DeSmuME](https://desmume.org/)|
 | Platform | Emulator |
 | --- | --- |
 |Windows|[Dolphin](https://dolphin-emu.org/)|
+|Mac|[Dolphin](https://dolphin-emu.org/)|
+|Linux|[Dolphin](https://dolphin-emu.org/)|
+|Android|[Dolphin](https://dolphin-emulator.en.uptodown.com/android)|
 
 &nbsp;
 **Nintendo Wii U**


### PR DESCRIPTION
Added Mac, Linux, and Android listings for Dolphin as a Wii emulator