### PR TITLE
Updated SpotX with MacOS links, Removed BlockTheSpot

### DIFF
--- a/Audio/Music.md
+++ b/Audio/Music.md
@@ -52,7 +52,7 @@ description: List of sources for getting all genres of Music.
 [**spotDL**](https://github.com/spotDL/spotify-downloader) - Download your Spotify playlists and songs along with album art and metadata fetched from YouTube.  
 *<small>This tool does not download songs directly from Spotify.</small>*
 
-**[SpotX](https://github.com/amd64fox/SpotX)** & [**BlockTheSpot**](https://github.com/mrpond/BlockTheSpot) - Multi-purpose AdBlockers and skip-bypasses for the Windows Spotify Desktop application.
+**[SpotX](https://github.com/SpotX-CLI)** - Block video, audio and banner ads on Spotify [Windows](https://github.com/SpotX-CLI/SpotX-Win) and [MacOS](https://github.com/SpotX-CLI/SpotX-Mac) and also unlock more premium and experimental features.
 
 [**YT-DLP**](https://github.com/yt-dlp/yt-dlp) - Can download from over 1500 sites including: Crunchyroll, Funimation, SoundCloud, Bandcamp, PornHub and more. [Link](https://github.com/yt-dlp/yt-dlp/blob/master/supportedsites.md) to all supported sites.  
 *<small>Actively maintained fork of the popular YouTube Downloader [youtube-dl](https://ytdl-org.github.io/youtube-dl/) with more functionality.</small>*


### PR DESCRIPTION
- Removed BlockTheSpot as we are decommissioning it and it wont be supported after the next Spotify patch breaking update.
- SpotX now also supports MacOS