### PR TITLE
Replace Sci-Hub X Now's chrome extension link with their github's

### DIFF
--- a/Literature/e-Books.md
+++ b/Literature/e-Books.md
@@ -32,8 +32,8 @@ description: Reliable sources to obtain e-Books.
 &nbsp;
 # Scientific Journals/Technical Manuals
 
-- [**Sci-Hub (.se)**](https://sci-hub.se/) | [**.st**](https://sci-hub.st/) | [**.ru**](https://sci-hub.ru/)    
-&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;[Sci-Hub X Now!](https://github.com/gchenfc/sci-hub-now)
+- [**Sci-Hub (.se)**](https://sci-hub.se/) | [**.st**](https://sci-hub.st/) | [**.ru**](https://sci-hub.ru/)  
+&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;[Sci-Hub X Now!](https://github.com/gchenfc/sci-hub-now) - Opens the Sci-Hub page for the article you want to read.  
 &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;[Zotero Scihub](https://github.com/ethanwillis/zotero-scihub) - Addon for [Zotero](https://www.zotero.org/) and [Juris-M](https://juris-m.github.io/) to automatically download PDFs from Sci-Hub.
 - [**SciMag**](https://libgen.rs/scimag/) - Scientific Articles section of LibGen.
 - [**Free Full PDF**](https://freefullpdf.com/)

--- a/Literature/e-Books.md
+++ b/Literature/e-Books.md
@@ -33,7 +33,7 @@ description: Reliable sources to obtain e-Books.
 # Scientific Journals/Technical Manuals
 
 - [**Sci-Hub (.se)**](https://sci-hub.se/) | [**.st**](https://sci-hub.st/) | [**.ru**](https://sci-hub.ru/)    
-&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;[Sci-Hub X Now!](https://github.com/gchenfc/sci-hub-now) [Github]
+&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;[Sci-Hub X Now!](https://github.com/gchenfc/sci-hub-now)
 &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;[Zotero Scihub](https://github.com/ethanwillis/zotero-scihub) - Addon for [Zotero](https://www.zotero.org/) and [Juris-M](https://juris-m.github.io/) to automatically download PDFs from Sci-Hub.
 - [**SciMag**](https://libgen.rs/scimag/) - Scientific Articles section of LibGen.
 - [**Free Full PDF**](https://freefullpdf.com/)

--- a/Literature/e-Books.md
+++ b/Literature/e-Books.md
@@ -33,7 +33,7 @@ description: Reliable sources to obtain e-Books.
 # Scientific Journals/Technical Manuals
 
 - [**Sci-Hub (.se)**](https://sci-hub.se/) | [**.st**](https://sci-hub.st/) | [**.ru**](https://sci-hub.ru/)    
-&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;[Sci-Hub X Now!](https://chrome.google.com/webstore/detail/sci-hub-x-now/gmmnidkpkgiohfdoenhpghbilmeeagjj) (Chromium) - Opens the sci-hub page for the article you want to read.  
+&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;[Sci-Hub X Now!](https://github.com/gchenfc/sci-hub-now) [Github]
 &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;[Zotero Scihub](https://github.com/ethanwillis/zotero-scihub) - Addon for [Zotero](https://www.zotero.org/) and [Juris-M](https://juris-m.github.io/) to automatically download PDFs from Sci-Hub.
 - [**SciMag**](https://libgen.rs/scimag/) - Scientific Articles section of LibGen.
 - [**Free Full PDF**](https://freefullpdf.com/)


### PR DESCRIPTION
Previously the website listed only the chrome extension, but their Github repo lists also the firefox extension and the edge extension, for whoever needs them.