### PR TITLE
Add malwarewatch.org

### DIFF
--- a/PC-Software/Software.md
+++ b/PC-Software/Software.md
@@ -55,10 +55,6 @@ Big sites for loads of Educational content including: tutorials, CG assets, plug
 
 Has plugins and addons for various Adobe apps, it is recommended you only download these from the site.
 
-[**Malwarewatch.org**](https://dl.malwarewatch.org/windows/activation/)
-
-Malwarewatch.org is a software archive website provided by [Enderman](https://www.youtube.com/endermanch) that contains downloads from various softwares, including most of Windows and DOS images.
-
 # Activation
 
 [**Microsoft Activation Scripts (MAS)**](https://massgrave.dev/)
@@ -68,6 +64,12 @@ Open source activator that includes various scripts for Windows and Office using
 [**Malwarewatch.org's activation keys**](https://dl.malwarewatch.org/windows/activation/)
 
 Malwarewatch.org (software archive website provided by [Enderman](https://www.youtube.com/endermanch)) provides activation keys from Windows XP and before, as well as downloads of activators for Windows Vista and after.
+
+# Misc
+
+[**Malwarewatch.org**](https://dl.malwarewatch.org/windows/activation/)
+
+Malwarewatch.org is a software archive website provided by [Enderman](https://www.youtube.com/endermanch) that contains downloads from various softwares, including most of Windows and DOS images.
 
 ## Apps
 

--- a/PC-Software/Software.md
+++ b/PC-Software/Software.md
@@ -69,7 +69,7 @@ Malwarewatch.org (software archive website provided by [Enderman](https://www.yo
 
 [**Malwarewatch.org**](https://dl.malwarewatch.org/windows/activation/)
 
-Malwarewatch.org is a software archive website provided by [Enderman](https://www.youtube.com/endermanch) that contains downloads from various softwares, including most of Windows and DOS images.
+Malwarewatch.org, [Enderman](https://www.youtube.com/endermanch)'s personal website, has a software archive that contains downloads from various softwares, including most of Windows and DOS images.
 
 ## Apps
 

--- a/PC-Software/Software.md
+++ b/PC-Software/Software.md
@@ -55,11 +55,19 @@ Big sites for loads of Educational content including: tutorials, CG assets, plug
 
 Has plugins and addons for various Adobe apps, it is recommended you only download these from the site.
 
+[**Malwarewatch.org**](https://dl.malwarewatch.org/windows/activation/)
+
+Malwarewatch.org is a software archive website provided by [Enderman](https://www.youtube.com/endermanch) that contains downloads from various softwares, including most of Windows and DOS images.
+
 # Activation
 
 [**Microsoft Activation Scripts (MAS)**](https://massgrave.dev/)
 
 Open source activator that includes various scripts for Windows and Office using HWID / KMS38 / Online KMS activation methods with the focus on fewer antivirus detections.
+
+[**Malwarewatch.org's activation keys**](https://dl.malwarewatch.org/windows/activation/)
+
+Malwarewatch.org (software archive website provided by [Enderman](https://www.youtube.com/endermanch)) provides activation keys from Windows XP and before, as well as downloads of activators for Windows Vista and after.
 
 ## Apps
 


### PR DESCRIPTION
This will add [malwarewatch.org's software archive](https://dl.malwarewatch.org) to the list at PC Software/Software. It is listed in two sections (Activators and Misc) because it both contains program/ISO downloads as well as activation keys. And no this site does not give any malwares, even more because both their malware repo and the software repo are separated from each other.

I'll consider any suggestions to move the one at Misc to another place if so, since I don't know which place it is the best to put it