### PR TITLE
Updated PreDB

### DIFF
--- a/Scene/PreDBs.md
+++ b/Scene/PreDBs.md
@@ -15,11 +15,9 @@ As listed in the [**Scene Glossary**](/Scene-Glossary),
 
 ## PreDB Sites
 - **[xREL](https://www.xrel.to/releases.html#)** 
-- **[PreDB.live](https://predb.live/)**
 - **[PreDB.org](https://www.predb.org/)**  
-- **[PreDB.de](https://predb.de/)**  
+- **[PreDB.net](https://predb.net/)**  
 - **[PreDB.me](https://predb.me/)**   
-- **[Pre.Corrupt-net](https://pre.corrupt-net.org/)**
 &nbsp;  
 &nbsp;
 ## Pre IRC Channels  


### PR DESCRIPTION
I Updated the PreDB section:
- Changed https://predb.de to https://predb.net (.de is redirecting to .net)
- Removed https://predb.live - Website loads but no releases are displayed since months.
- Removed https://pre.corrupt-net.org - Seems pretty dead