### PR TITLE
fix: update links for kemono & coomer

### DIFF
--- a/Utilities/Leaks.md
+++ b/Utilities/Leaks.md
@@ -22,7 +22,7 @@ description: Sources for Leaks, Account Generators and more.
 
 # Paid Content Leaks
 
-[**Kemono**](https://kemono.party/) & [**Coomer**](https://coomer.party/) - The successors to yiff.party, they have Leaks for sites like Patreon, OnlyFans and more which are all user-submitted with an automated process.  
+[**Kemono**](https://kemono.su/) & [**Coomer**](https://coomer.su/) - The successors to yiff.party, they have Leaks for sites like Patreon, OnlyFans and more which are all user-submitted with an automated process.  
 
 [**Crackx Porn**](https://crackx.to/Forum-Porn) | [**Nulled ThotHub**](https://www.nulled.to/forum/223-thothub/) | [**Cracked.to Porn**](https://cracked.to/Forum-Porn) - More 18+ categories for the Forums listed above, OnlyFans and Paid Porn sites mostly.
 


### PR DESCRIPTION
![image](https://github.com/rippedpiracy/docs/assets/104658278/df8fac25-6841-4a06-872f-eadd6e76220b)
the .su domain has been an alternative for a while now, and it will soon be the primary URL