### PR TITLE
WatchCartoonsOnline removal.

### DIFF
--- a/TV/Shows.md
+++ b/TV/Shows.md
@@ -10,8 +10,6 @@ description: List of sites to Stream and Download TV Shows and Movies.
 [**SFlix**](https://sflix.to/home) - Streaming site with a UI similar to Prime Video, **_beware of Pop-ups._**  
 *<small>There are some Anti-Popup addons in our <a target="_self" href="/Utilities/Misc">Misc</a> section.</small>*
 
-[**WatchCartoonsOnline**](https://watchcartoononline.com) - Site for Cartoons and subbed/dubbed Anime.
-
 [**Seez**](https://seez.su) - A streaming webpage with a modern UI. Constantly updated with Indian content. Has additional hosts and subtitles.
 
 [**StreamingCommunity**](https://streamingcommunity.codes/) - Constantly updated site with Italian Dubbed/Subbed Content, a UI similar to Netflix.


### PR DESCRIPTION
Site no longer allows you to play videos with Adblock enabled. Should be removed.

Tested with Ublock Origin on Firefox 118.0.2
![rel](https://github.com/rippedpiracy/docs/assets/25989889/c10067d1-2196-462c-9322-22ba417bbece)
