### PR TITLE
Adding New sites, Adding Good Practices, Removing Dead links & More

### DIFF
--- a/Consoles/Emulation.md
+++ b/Consoles/Emulation.md
@@ -9,14 +9,9 @@ description: Resources for Emulation and sites that offer ROM Downloads.
 
 ## ROMs
 
-**[ROMSPURE](https://romspure.cc/roms) (DDL)**
+**[Myrient](https://myrient.erista.me/) (DDL)**
 
-Contains large collection of ROMs from every type of system.
-
-**[RomUlation](https://www.romulation.org/) (DDL)**  
-
-Offering ROM Downloads since 2004.  
-*<small><b>Ignore any Pop-ups/Banners about faster Downloads/Premium. Try another ROM site if the Download is for Premium Users.</b></small>*
+Website focused on Game preservation with lots of different systems to choose from.
 
 **[r/ROMs Megathread](https://r-roms.github.io/) (DDL)**
 
@@ -25,6 +20,15 @@ The r/ROMs Megathread, with links for Popular and Arcade ROMs, visualized with m
 **[NoPayStation](https://nopaystation.com/) (DDL)**
 
  The best place to get VITA, PS3, PSP, PSX Games / DLCs and more, directly from Sony's servers with no Middle-Man.
+
+**[ROMSPURE](https://romspure.cc/roms) (DDL)**
+
+Contains large collection of ROMs from every type of system.
+
+**[RomUlation](https://www.romulation.org/) (DDL)**  
+
+Offering ROM Downloads since 2004.  
+*<small><b>Ignore any Pop-ups/Banners about faster Downloads/Premium. Try another ROM site if the Download is for Premium Users.</b></small>*
 
 **[Vimm's Lair: Vault](https://vimm.net/vault/) (DDL / Torrent)**
 
@@ -50,10 +54,6 @@ Changes domains frequently, offers NSP / XCI files for Switch Games, with Update
 **[CDRomance](https://cdromance.org/) (DDL)**
 
 A Site similar to [Ziperto](https://ziperto.com) which offers more ROMs for different consoles, uploaded directly to the site.
-
-**[Myrient](https://myrient.erista.me/) (DDL)**
-
-Website focused on Game preservation with lots of different systems to choose from.
 
 ## Emulators
 

--- a/Consoles/Emulation.md
+++ b/Consoles/Emulation.md
@@ -66,7 +66,7 @@ Some examples for scam apps are: PCSX4, PCSX5, PSemuX, RPCS4.**</small>
 ## Apps
 
 [**qBittorrent**](https://www.qbittorrent.org) | [**Deluge**](https://www.deluge-torrent.org) | [**Transmission**](https://transmissionbt.com/) - Free, Lightweight and open source Torrent Clients.  
-*<small>We do not recommend using [µTorrent](https://www.utorrent.com) or [BitTorrent](https://www.bittorrent.com/), as it came bundled with Adware, Spyware, and Crypto-Miners in the past [<sup>[1]</sup>](https://www.trustedreviews.com/news/utorrent-silently-installing-bundled-bitcoin-mining-software-2931825). In its current state, it's Adware and Bloatware. We don't recommend using µTorrent v2.2.1 either due to confirmed Security Exploits.</small>*  
+*<small>We do not recommend using **µTorrent** or **BitTorrent**, as it came bundled with Adware, Spyware, and Crypto-Miners in the past [<sup>[1]</sup>](https://www.trustedreviews.com/news/utorrent-silently-installing-bundled-bitcoin-mining-software-2931825). In its current state, it's Adware and Bloatware. We don't recommend using µTorrent v2.2.1 either due to confirmed Security Exploits.</small>*  
 &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;[qBitorrent Guide](https://gitlab.com/ZediAlreadyTaken/guides/-/blob/main/qbittorrent.md) - A guide for configuring qBitorrent.
 
 [**AB-DM**](https://abdownloadmanager.com/) | [**IDM**](https://www.internetdownloadmanager.com/) | [**JD2**](https://jdownloader.org/jdownloader2) | [**Motrix**](https://motrix.app/) | [**FDM**](https://www.freedownloadmanager.org/) - Download Managers that can boost Download speeds. Motrix and FDM support Torrenting, and JD2 is best for downloading multiple files simultaneously. IDM is paid.  

--- a/Consoles/Homebrew.md
+++ b/Consoles/Homebrew.md
@@ -16,7 +16,7 @@ description: Guides for obtaining Homebrew on various Consoles.
 [**NH Switch Guide**](https://nh-server.github.io/switch-guide/) - A Nintendo Switch guide.  
 <sub>Consider checking out [GBATemp](https://gbatemp.net/threads/the-ultimate-list-of-mods-to-enter-rcm.502145/) to see other ways to enter RCM without soldering, but it is recommended to buy an RCM Jig.</sub>  
 
-[**WiiBrew**](https://wiibrew.org/wiki/Main_Page) - A wiki dedicated to Homebrew on the Nintendo Wii U.  
+[**WiiBrew**](https://wiibrew.org/wiki/Main_Page) - A wiki dedicated to Homebrew on the Nintendo Wii.  
 [**Wii Guide**](https://wii.hacks.guide) - Guide made by the NH team to Homebrew the Wii.
 
 [**WiiUBrew**](https://wiiubrew.org/wiki/Main_Page) - A wiki dedicated to Homebrew on the Nintendo Wii U.  

--- a/PC-Software/Games.md
+++ b/PC-Software/Games.md
@@ -36,10 +36,6 @@ Repacks contain optional lossily compressed assets to reduce Game size further i
 
 ## General DDL
 
-**[SteamRIP](https://steamrip.com/) (DDL)**
-
-Uploads Pre installed Steam Games And mostly Offers Multiple File Hosters To download from And Have Both Torrent and DDL Options For Some Games. Takes Requests.
-
 **[Ova Games](https://ovagames.com) (DDL)**
 
 A site which focuses on re-uploading Repacks, P2P Cracks, Scene Releases and GOG Rips to various hosts. Rarely includes Torrent links. Takes requests.
@@ -52,10 +48,6 @@ Uploads Repacks and Scene Releases for PC and various Consoles. Takes requests.
 
 Every GOG DRM-free Game, ripped and re-uploaded on Mirrors. Every installer is untouched and has a cryptographic SHA-256 key from GOG.  
 *<small>This site is also accessible through [Tor](http://goggamespyi7b6ybpnpnlwhb4md6owgbijfsuj6z5hesqt3yfyz42rad.onion).</small>*
-
-**[SteamGG](https://steamgg.net/) (DDL)**
-
-Pre-installed Games with Steam in mind. Games Usually on Multiple File Hosters. Takes Requests.
 
 **[GamesDrive](https://gamesdrive.net) (DDL)**
 

--- a/PC-Software/Games.md
+++ b/PC-Software/Games.md
@@ -36,6 +36,10 @@ Repacks contain optional lossily compressed assets to reduce Game size further i
 
 ## General DDL
 
+**[SteamRIP](https://steamrip.com/) (DDL)**
+
+Uploads Pre installed Steam Games And mostly Offers Multiple File Hosters To download from And Have Both Torrent and DDL Options For Some Games. Takes Requests.
+
 **[Ova Games](https://ovagames.com) (DDL)**
 
 A site which focuses on re-uploading Repacks, P2P Cracks, Scene Releases and GOG Rips to various hosts. Rarely includes Torrent links. Takes requests.
@@ -48,6 +52,10 @@ Uploads Repacks and Scene Releases for PC and various Consoles. Takes requests.
 
 Every GOG DRM-free Game, ripped and re-uploaded on Mirrors. Every installer is untouched and has a cryptographic SHA-256 key from GOG.  
 *<small>This site is also accessible through [Tor](http://goggamespyi7b6ybpnpnlwhb4md6owgbijfsuj6z5hesqt3yfyz42rad.onion).</small>*
+
+**[SteamGG](https://steamgg.net/) (DDL)**
+
+Pre-installed Games with Steam in mind. Games Usually on Multiple File Hosters. Takes Requests.
 
 **[GamesDrive](https://gamesdrive.net) (DDL)**
 
@@ -102,7 +110,7 @@ Preservation project for Adobe Flash Games. Has over 90k Games in its [library](
 ## Apps
 
 [**qBittorrent**](https://www.qbittorrent.org) | [**Deluge**](https://www.deluge-torrent.org) | [**Transmission**](https://transmissionbt.com/) - Free, Lightweight and open source Torrent Clients.  
-*<small>We do not recommend using [µTorrent](https://www.utorrent.com) or [BitTorrent](https://www.bittorrent.com/), as it came bundled with Adware, Spyware, and Crypto-Miners in the past [<sup>[1]</sup>](https://www.trustedreviews.com/news/utorrent-silently-installing-bundled-bitcoin-mining-software-2931825). In its current state, it's Adware and Bloatware. We don't recommend using µTorrent v2.2.1 either due to confirmed Security Exploits.</small>*  
+*<small>We do not recommend using **µTorrent** or **BitTorrent**, as it came bundled with Adware, Spyware, and Crypto-Miners in the past [<sup>[1]</sup>](https://www.trustedreviews.com/news/utorrent-silently-installing-bundled-bitcoin-mining-software-2931825). In its current state, it's Adware and Bloatware. We don't recommend using µTorrent v2.2.1 either due to confirmed Security Exploits.</small>*  
 &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;[qBittorrent Enhanced Edition](https://github.com/c0re100/qBittorrent-Enhanced-Edition/blob/-/README.md) - A qBittorrent fork with enhanced privacy (IP filtering, auto-ban bots and copyright trolls, auto-update public trackers).  
 &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;[qBittorrent Guide](https://gitlab.com/ZediAlreadyTaken/guides/-/blob/main/qbittorrent.md) - A guide for configuring qBittorrent.  
 

--- a/PC-Software/Software.md
+++ b/PC-Software/Software.md
@@ -19,6 +19,14 @@ You can mostly find Adobe Products and Autodesk Software.
 
 # Direct Download
 
+**[CracksURL](https://cracksurl.com/)**
+
+General DDL Site With a Long History And Library. Usually Has multiple File Hosters.
+
+**[Lrepacks](https://lrepacks.net/)**
+
+**Translator Recommended** Russian Site With A Bunch of software. 
+
 **[Nsane Forums](https://nsaneforums.com/)**
 
 Forum focused on News for everything Piracy, with downloads for Software and Utilites. Forum, **_Requires Sign-up._**  
@@ -59,7 +67,7 @@ Open source activator that includes various scripts for Windows and Microsoft Of
 ## Apps
 
 [**qBittorrent**](https://www.qbittorrent.org) | [**Deluge**](https://www.deluge-torrent.org) | [**Transmission**](https://transmissionbt.com/) - Free, Lightweight and open source Torrent Clients.  
-*<small>We do not recommend using [µTorrent](https://www.utorrent.com) or [BitTorrent](https://www.bittorrent.com/), as it came bundled with Adware, Spyware, and Crypto-Miners in the past [<sup>[1]</sup>](https://www.trustedreviews.com/news/utorrent-silently-installing-bundled-bitcoin-mining-software-2931825). In its current state, it's Adware and Bloatware. We don't recommend using µTorrent v2.2.1 either due to confirmed Security Exploits.</small>*  
+*<small>We do not recommend using **µTorrent** or **BitTorrent**, as it came bundled with Adware, Spyware, and Crypto-Miners in the past [<sup>[1]</sup>](https://www.trustedreviews.com/news/utorrent-silently-installing-bundled-bitcoin-mining-software-2931825). In its current state, it's Adware and Bloatware. We don't recommend using µTorrent v2.2.1 either due to confirmed Security Exploits.</small>*  
 &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;[qBittorrent Enhanced Edition](https://github.com/c0re100/qBittorrent-Enhanced-Edition/blob/-/README.md) - A qBittorrent fork with enhanced privacy (IP filtering, auto-ban bots and copyright trolls, auto-update public trackers).  
 &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;[qBittorrent Guide](https://gitlab.com/ZediAlreadyTaken/guides/-/blob/main/qbittorrent.md) - A guide for configuring qBittorrent.  
 

--- a/PC-Software/Software.md
+++ b/PC-Software/Software.md
@@ -23,10 +23,6 @@ You can mostly find Adobe Products and Autodesk Software.
 
 General DDL Site With a Long History And Library. Usually Has multiple File Hosters.
 
-**[Lrepacks](https://lrepacks.net/)**
-
-**Translator Recommended** Russian Site With A Bunch of software. 
-
 **[Nsane Forums](https://nsaneforums.com/)**
 
 Forum focused on News for everything Piracy, with downloads for Software and Utilites. Forum, **_Requires Sign-up._**  

--- a/TV/Anime.md
+++ b/TV/Anime.md
@@ -34,7 +34,7 @@ description: Comprehensive list of sites for downloading and streaming Anime.
 # Apps
 
 [**qBittorrent**](https://www.qbittorrent.org) | [**Deluge**](https://www.deluge-torrent.org) | [**Transmission**](https://transmissionbt.com/) - Free, Lightweight and open source Torrent Clients.  
-*<small>We do not recommend using [µTorrent](https://www.utorrent.com) or [BitTorrent](https://www.bittorrent.com/), as it came bundled with Adware, Spyware, and Crypto-Miners in the past [<sup>[1]</sup>](https://www.trustedreviews.com/news/utorrent-silently-installing-bundled-bitcoin-mining-software-2931825). In its current state, it's Adware and Bloatware. We don't recommend using µTorrent v2.2.1 either due to confirmed Security Exploits.</small>*  
+*<small>We do not recommend using **µTorrent** or **BitTorrent**, as it came bundled with Adware, Spyware, and Crypto-Miners in the past [<sup>[1]</sup>](https://www.trustedreviews.com/news/utorrent-silently-installing-bundled-bitcoin-mining-software-2931825). In its current state, it's Adware and Bloatware. We don't recommend using µTorrent v2.2.1 either due to confirmed Security Exploits.</small>*  
 &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;[qBittorrent Enhanced Edition](https://github.com/c0re100/qBittorrent-Enhanced-Edition/blob/-/README.md) - A qBittorrent fork with enhanced privacy (IP filtering, auto-ban bots and copyright trolls, auto-update public trackers).  
 &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;[qBittorrent Guide](https://gitlab.com/ZediAlreadyTaken/guides/-/blob/main/qbittorrent.md) - A guide for configuring qBittorrent.  
 

--- a/TV/Shows.md
+++ b/TV/Shows.md
@@ -12,6 +12,8 @@ description: List of sites to Stream and Download TV Shows and Movies.
 [**SFlix**](https://sflix.to/home) | [**MovieOrca**](https://movieorca.com) - Streaming sites with a UI similar to Prime Video, **_beware of Pop-ups._**  
 *<small>There are some Anti-Popup filters in our <a target="_self" href="/Utilities/Misc">Misc</a> section.</small>*
 
+**[Hexa](https://hexa.watch/)** - Simple to Use Streaming site With A clean UI. Watch Parties Supported. 
+
 [**WatchCartoonsOnline**](https://wcofun.net) - Site for Cartoons and subbed/dubbed Anime.
 
 [**StreamingCommunity**](https://t.me/+YID6ZoJtgjg5NGEx) - Constantly updated site with Italian Dubbed/Subbed Content, similar to Netflix.
@@ -27,7 +29,7 @@ Enable file explorer on Windows to display file extensions and make sure the fil
 **[1337x](https://1337x.to) (Torrent)** - Torrent Tracker with an enourmous amount of Movies, TV Shows and everything in-between.  
 Quality can vary from one Release to another.
 
-**[TorrentGalaxy](https://torrentgalaxy.to/) (Torrent)** - One of the better sources for new Movies and TV shows.
+**[RGshows](https://www.rgshows.me/?p=1) (DDL)** - Site With Movies, Tv, Anime, All At 4k Quality. 
 
 **[OlaMovies](https://olamovies.rent/) (DDL)** - Site that has downloads for higher quality and relatively storage-friendly encodes, you can find Bollywood media here as well.
 *Join their [Telegram Channel](https://telegram.me/olamovies_officialv6) for domain updates.*

--- a/TV/Shows.md
+++ b/TV/Shows.md
@@ -55,7 +55,7 @@ Their [Subreddit](https://reddit.com/r/PopCornTimeApp) can be visited for more i
 **_Only use the site we linked here as there are many fake links out there._**  
 
 [**qBittorrent**](https://www.qbittorrent.org) | [**Deluge**](https://www.deluge-torrent.org) | [**Transmission**](https://transmissionbt.com/) - Free, Lightweight and open source Torrent Clients.  
-*<small>We do not recommend using [µTorrent](https://www.utorrent.com) or [BitTorrent](https://www.bittorrent.com/), as it came bundled with Adware, Spyware, and Crypto-Miners in the past [<sup>[1]</sup>](https://www.trustedreviews.com/news/utorrent-silently-installing-bundled-bitcoin-mining-software-2931825). In its current state, it's Adware and Bloatware. We don't recommend using µTorrent v2.2.1 either due to confirmed Security Exploits.</small>*  
+*<small>We do not recommend using **µTorrent** or **BitTorrent**, as it came bundled with Adware, Spyware, and Crypto-Miners in the past [<sup>[1]</sup>](https://www.trustedreviews.com/news/utorrent-silently-installing-bundled-bitcoin-mining-software-2931825). In its current state, it's Adware and Bloatware. We don't recommend using µTorrent v2.2.1 either due to confirmed Security Exploits.</small>*  
 &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;[qBittorrent Enhanced Edition](https://github.com/c0re100/qBittorrent-Enhanced-Edition/blob/-/README.md) - A qBittorrent fork with enhanced privacy (IP filtering, auto-ban bots and copyright trolls, auto-update public trackers).  
 &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;[qBittorrent Guide](https://gitlab.com/ZediAlreadyTaken/guides/-/blob/main/qbittorrent.md) - A guide for configuring qBittorrent.  
 

--- a/Utilities/Misc.md
+++ b/Utilities/Misc.md
@@ -99,7 +99,7 @@ It may break some sites.
 *<small>For GoodByeDPI GUI to work you will have to disable "Settings > Software Settings > Auto Check Updates" and relaunch the app.</small>*
 
 [**qBittorrent**](https://www.qbittorrent.org) | [**Deluge**](https://www.deluge-torrent.org) | [**Transmission**](https://transmissionbt.com/) - Free, Lightweight and open source Torrent Clients.  
-*<small>We do not recommend using [µTorrent](https://www.utorrent.com) or [BitTorrent](https://www.bittorrent.com/), as it came bundled with Adware, Spyware, and Crypto-Miners in the past [<sup>[1]</sup>](https://www.trustedreviews.com/news/utorrent-silently-installing-bundled-bitcoin-mining-software-2931825). In its current state, it's Adware and Bloatware. We don't recommend using µTorrent v2.2.1 either due to confirmed Security Exploits.</small>*  
+*<small>We do not recommend using **µTorrent** or **BitTorrent**, as it came bundled with Adware, Spyware, and Crypto-Miners in the past [<sup>[1]</sup>](https://www.trustedreviews.com/news/utorrent-silently-installing-bundled-bitcoin-mining-software-2931825). In its current state, it's Adware and Bloatware. We don't recommend using µTorrent v2.2.1 either due to confirmed Security Exploits.</small>*  
 &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;[qBittorrent Enhanced Edition](https://github.com/c0re100/qBittorrent-Enhanced-Edition/blob/-/README.md) - A qBittorrent fork with enhanced privacy (IP filtering, auto-ban bots and copyright trolls, auto-update public trackers).  
 &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;[qBittorrent Guide](https://gitlab.com/ZediAlreadyTaken/guides/-/blob/main/qbittorrent.md) - A guide for configuring qBittorrent.  
 


### PR DESCRIPTION
Heres a Few Updates To Add more links, Update Certain Stuff And more.

**Every site i added Is starred in either FREEMEDIAHECKYEAH or r/piracy.**

Heres a Detailed Breakdown of everything i did:

- Added SteamRIP And SteamGG in Games **And made the utorrent and bittorrent links in the general torrenting message non clickable. otherwise it would be bad practice.**

- Added CracksURL and Lrepacks in Software **And made the utorrent and bittorrent links in the general torrenting message non clickable. otherwise it would be bad practice.**

- Moved RomsPURE, nopaystation, myrient and r/roms in Emulation **And made the utorrent and bittorrent links in the general torrenting message non clickable. otherwise it would be bad practice.**

- Fixed Wiibrew's Description From Saying "Wii U" to "Wii".

- Removed Torrent Galaxy (Dead Site) And Added Hexa in Streaming And RGshows in Shows **And made the utorrent and bittorrent links in the general torrenting message non clickable. otherwise it would be bad practice.**

- made the utorrent and bittorrent links in the general torrenting message in Anime non clickable. otherwise it would be bad practice.

- made the utorrent and bittorrent links in the general torrenting message in Misc non clickable. otherwise it would be bad practice.


Let Me Know if you want any of these changes reversed, removed, or anything really.