### PR TITLE
Replace Aliucord with Revenge

### DIFF
--- a/Mobile/Android.md
+++ b/Mobile/Android.md
@@ -87,8 +87,8 @@ Here's a [Guide](https://blog.mozilla.org/addons/2020/09/29/expanded-extension-s
 [**ReVanced**](https://github.com/revanced/revanced-manager) - Android App patcher that provides patches to popular apps such as YouTube, Twitter and Reddit.    
 *<small>It requires the need of a microG client for YouTube and YouTube music if your device does not have root access. At the moment, the most compatible microG manager with ReVanced according to the community is [Vanced MicroG](https://github.com/TeamVanced/VancedMicroG), but it may be replaced in the future.</small>*
 
-[**Aliucord**](https://github.com/Aliucord/Aliucord) - Plugin-based Discord (Kotlin - below 126.21) client mod for Android.  
-*<small>Note that Aliucord only supports versions **before the React Native update** (all versions before 126.21)</small>*
+[**Revenge**](https://github.com/revenge-mod/revenge-bundle) - Plugin-based Discord client mod for Android.  
+*<small>Supports root (with Xposed) as well as non-root.</small>*
 
 [**AyuGram**](https://t.me/ayugramfcm) | [**Nekogram**](https://nekogram.app/download) - Telegram Client with Ghost mode, Message history, disabled ads and more.
 


### PR DESCRIPTION
Aliucord was removed because it is outdated. Revenge was added as the recommended Discord client mod, as it is actively developed, up-to-date, and supports both root and non-root.