### PR TITLE
add android rooting and bottles, refreshed links and fixed typos

### DIFF
--- a/Consoles/Emulation.mdx
+++ b/Consoles/Emulation.mdx
@@ -59,7 +59,7 @@ _<small>Make sure to check with your Emulator [here](https://emulation.gametechw
 
 [**qBittorrent**](https://www.qbittorrent.org) | [**Deluge**](https://www.deluge-torrent.org) | [**Transmission**](https://transmissionbt.com/) - Free, Lightweight and open source Torrent Clients.  
 _<small>We do not recommend using [uTorrent](https://www.utorrent.com) or [BitTorrent](https://www.bittorrent.com/), as it came bundled with Adware, Spyware, and Crypto-Miners in the past [<sup>[1]</sup>](https://www.trustedreviews.com/news/utorrent-silently-installing-bundled-bitcoin-mining-software-2931825). In its current state, it's Adware and Bloatware. We don't recommend using uTorrent v2.2.1 either due to confirmed Security Exploits.</small>_  
-&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;[qBitorrent Guide](https://gitlab.com/ZediAlreadyTaken/guides/-/blob/main/qbittorrent.md) - A guide for configuring qBitorrent.
+&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;[qBittorrent Guide](https://gitlab.com/ZediAlreadyTaken/guides/-/blob/main/qbittorrent.md) - A guide for configuring qBittorrent.
 
 [**AB-DM**](https://abdownloadmanager.com/) | [**IDM**](https://www.internetdownloadmanager.com/) | [**JD2**](https://jdownloader.org/jdownloader2) | [**Motrix**](https://motrix.app/) | [**FDM**](https://www.freedownloadmanager.org/) - Download Managers that can boost Download speeds. Motrix and FDM support Torrenting, and JD2 is best for downloading multiple files simultaneously. IDM is paid.  
 &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;[Elephant](https://github.com/meowcateatrat/elephant) - Adds YT-DLP support to FDM, meaning it can download from all [these](https://github.com/yt-dlp/yt-dlp/blob/master/supportedsites.md) sites.  

--- a/Literature/Manga.mdx
+++ b/Literature/Manga.mdx
@@ -49,7 +49,7 @@ Remember to always use an AdBlocker like [uBlock Origin](https://github.com/gorh
 
 _Methods to rip Manga from various sites._
 
-- [**Manga Downloader**](https://redsquirrel87.altervista.org/doku.php/manga-downloader) - A simple yet sleek Java-based app to download images from raw sites with internal descrambling and stitching. Supports forcing frameworks to download from unsupported sites. Example: tonarinoyj.jp isn't supported but can be used by forcing coreview.
+- [**JAM**](https://redsquirrel87.com/jam) - A simple yet sleek Java-based app to download images from raw sites with internal descrambling and stitching. Supports forcing frameworks to download from unsupported sites. Example: tonarinoyj.jp isn't supported but can be used by forcing coreview.
 - [**HaruNeko**](https://github.com/manga-download/haruneko) | [**HakuNeko**](https://hakuneko.download/) - Cross-platform downloader for manga and anime from various websites.
 - [**Zeen3 Ripsters Userscripts**](https://zeen3.gitlab.io/ripsters/) - Various raw site rippers; intended to save raw images from ja/zh/ko sites.  
   _<small>Use a Userscript Manager like [Violentmonkey](https://violentmonkey.github.io).</small>_

--- a/Mobile/Android.mdx
+++ b/Mobile/Android.mdx
@@ -3,6 +3,14 @@ title: Android
 description: List of useful Android mobile apps.
 ---
 
+## Rooting
+
+[**Magisk**](https://github.com/topjohnwu/Magisk) - A suite of open source software for customizing Android.
+
+[**KernelSU**](https://github.com/tiann/KernelSU) - A Kernel based root solution for Android.
+
+[**KernelSU-Next**](https://github.com/KernelSU-Next/KernelSU-Next) - An advanced Kernel based root solution for Android. 
+
 ## Application stores
 
 [**Mobilism**](https://forum.mobilism.me/) - Trusted Forum for downloading Modded APKs.  
@@ -44,7 +52,7 @@ Here's a [Guide](https://blog.mozilla.org/addons/2020/09/29/expanded-extension-s
 [**ByeDPI**](https://github.com/dovecoteescapee/ByeDPIAndroid) | [**PowerTunnel**](https://github.com/krlvm/PowerTunnel-Android) - Powerful tools to bypass DPI (Deep Packet Inspection) and censorship. Useful to unblock websites without relying on VPNs.
 
 [**AdAway**](https://adaway.org/) - Open-source mobile ad-blocker with a focus on privacy.    
-_<small>This app benefits from having root access.</small>_
+_<small>This app benefits from having [root access](#rooting).</small>_
 
 [**Bitwarden**](https://github.com/bitwarden/mobile) - Open-source & self-hostable password manager. [Material You](https://github.com/AChep/keyguard-app) client for the same, with better performance and additional features.
 
@@ -104,7 +112,7 @@ _<small>It only supports the last version **before the React Native update** (12
 ## Miscellaneous
 
 [**Lucky Patcher**](https://www.luckypatchers.com/) - Android app modifier which can be used to remove license verification, advertisements, change permissions, unlock in-app purchases etc.  
-_<small>This app isn't open source so giving it root access to use some of it's features is your responsibility!</small>_
+_<small>This app isn't open source so giving it [root access](#rooting) to use some of it's features is your responsibility!</small>_
 
 [**GameGuardian**](https://gameguardian.net/forum/) - A game/cheating app for Android. Similar to Cheat Engine on PC.  
-_<small>This app isn't open source so giving it root access to use some of it's features is your responsibility!</small>_
+_<small>This app isn't open source so giving it [root access](#rooting) to use some of it's features is your responsibility!</small>_

--- a/PC-Software/Games.mdx
+++ b/PC-Software/Games.mdx
@@ -141,6 +141,7 @@ _<small>A Guide for [wired](<https://github.com/alvr-org/ALVR/wiki/ALVR-wired-se
 [**Playnite**](https://playnite.link) - A Video-Game library manager with the goal to provide a unified interface for all Games, including but not limited to: Steam, GOG, Origin, Battle.net and Ubisoft. Also has Game emulation support.  
 _<small>Make sure to check out the [Add-ons](https://playnite.link/addons.html).</small>_  
 [**Lutris**](https://lutris.net/) - An easy to use game manager for Linux.
+[**Bottles**](https://usebottles.com/) - A tool to manage your Windows Games and Apps on Linux.
 
 [**CompactGUI**](https://github.com/ImminentFate/CompactGUI) | [**Compactor**](https://github.com/Freaky/Compactor) - Transparently compresses games, programs and other folders with virtually no performance loss.
 


### PR DESCRIPTION
- Add new Rooting section to Android.mdx (Magisk, KernelSU and KernelSU-Next) [FOSS]
- Link 'root access' metions to the new rooting section
- Update Manga Downloader -> JAM and fixed dead link
- Fix qBittorrent spelling in Emulation.mdx
- Add Bottles near Lutris as an alternative