### PR TITLE
Add Kettu to Android Section

### DIFF
--- a/Mobile/Android.mdx
+++ b/Mobile/Android.mdx
@@ -107,6 +107,8 @@ _<small>SD Maid 2/SE isn't feature complete as it is an in-progress reimaginatio
 [**Aliucord**](https://github.com/Aliucord/Aliucord) - Plugin-based Discord client mod for Android.  
 _<small>It only supports the last version **before the React Native update** (126.21)</small>_
 
+[**Kettu**](https://github.com/C0C0B01/Kettu) / [Plugins](https://plugins-list.pages.dev) - Plugin-based Discord modification for rooted and unrooted devices.
+
 [**AyuGram**](https://t.me/ayugramfcm) | [**Nekogram**](https://nekogram.app/download) - Telegram Client with Ghost mode, Message history, disabled ads and more.
 
 ## Miscellaneous


### PR DESCRIPTION
Kettu is not iOS exclusive, and does support Android devices with or without root.